### PR TITLE
fix @DSTransactional 无法获取注解属性|统一属性解析逻辑

### DIFF
--- a/dynamic-datasource-spring-boot-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAopConfiguration.java
+++ b/dynamic-datasource-spring-boot-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAopConfiguration.java
@@ -85,7 +85,8 @@ public class DynamicDataSourceAopConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = DynamicDataSourceProperties.PREFIX, name = "seata", havingValue = "false", matchIfMissing = true)
     public Advisor dynamicTransactionAdvisor() {
-        DynamicLocalTransactionInterceptor interceptor = new DynamicLocalTransactionInterceptor();
+        DynamicDatasourceAopProperties aopProperties = properties.getAop();
+        DynamicLocalTransactionInterceptor interceptor = new DynamicLocalTransactionInterceptor(aopProperties.getAllowedPublicOnly());
         return new DynamicDataSourceAnnotationAdvisor(interceptor, DSTransactional.class);
     }
 

--- a/dynamic-datasource-spring-boot3-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAopConfiguration.java
+++ b/dynamic-datasource-spring-boot3-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAopConfiguration.java
@@ -85,7 +85,8 @@ public class DynamicDataSourceAopConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = DynamicDataSourceProperties.PREFIX, name = "seata", havingValue = "false", matchIfMissing = true)
     public Advisor dynamicTransactionAdvisor() {
-        DynamicLocalTransactionInterceptor interceptor = new DynamicLocalTransactionInterceptor();
+        DynamicDatasourceAopProperties aopProperties = properties.getAop();
+        DynamicLocalTransactionInterceptor interceptor = new DynamicLocalTransactionInterceptor(aopProperties.getAllowedPublicOnly());
         return new DynamicDataSourceAnnotationAdvisor(interceptor, DSTransactional.class);
     }
 

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/annotation/BasicAttribute.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/annotation/BasicAttribute.java
@@ -1,0 +1,19 @@
+package com.baomidou.dynamic.datasource.annotation;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * The base kind all dynamicDatasource annotation attribute.
+ *
+ * @author zp
+ * @since 4.1.3
+ */
+@Data
+@AllArgsConstructor
+public class BasicAttribute<T> {
+    /**
+     * dataOperation
+     */
+    private T dataOperation;
+}

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicDataSourceAnnotationInterceptor.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/aop/DynamicDataSourceAnnotationInterceptor.java
@@ -16,6 +16,7 @@
 package com.baomidou.dynamic.datasource.aop;
 
 import com.baomidou.dynamic.datasource.processor.DsProcessor;
+import com.baomidou.dynamic.datasource.annotation.DS;
 import com.baomidou.dynamic.datasource.support.DataSourceClassResolver;
 import com.baomidou.dynamic.datasource.toolkit.DynamicDataSourceContextHolder;
 import org.aopalliance.intercept.MethodInterceptor;
@@ -66,7 +67,7 @@ public class DynamicDataSourceAnnotationInterceptor implements MethodInterceptor
      * @return dsKey
      */
     private String determineDatasourceKey(MethodInvocation invocation) {
-        String key = dataSourceClassResolver.findKey(invocation.getMethod(), invocation.getThis());
+        String key = dataSourceClassResolver.findKey(invocation.getMethod(), invocation.getThis(), DS.class);
         return key.startsWith(DYNAMIC_PREFIX) ? dsProcessor.determineDatasource(invocation, key) : key;
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ √] Bugfix
- [ ] Feature
- [√ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
修复@DSTransactional 无法获取类|接口|接口方法的注解属性，统一注解属性解析逻辑并将DataSourceClassResolver类中获取注解元信息的AnnotatedElementUtils.getMergedAnnotationAttributes()方法改为findMergedAnnotationAttributes()，前者不能获取到接口方法的注解元信息，导致可能导致切点切到但获取不到信息的情况。

**Other information:**
#542 


