### PR TITLE
Open and Fix NativeTest by Spring Framework under GraalVM CE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ env:
   MAVEN_OPTS: -Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true
 
 jobs:
-  # TODO
   test-graalvm-ce-ci:
     name: NativeTest CI - GraalVM CE ${{ matrix.java-version }} on ${{ matrix.os }} (This CI failure is reasonable)
     runs-on: ${{ matrix.os }}
@@ -45,7 +44,7 @@ jobs:
       - name: Build Spring Boot Starter 3 test with Maven
         run: |
           ./mvnw -T1C -B -PgenerateMetadata -DskipNativeTests clean test
-#          ./mvnw -am -pl dynamic-datasource-spring-boot3-starter -PnativeTestInSpringBoot T1C -B clean test
+          ./mvnw -am -pl dynamic-datasource-spring-boot3-starter -PnativeTestInSpringBoot -T1C -B clean test
   test-maximum-jdk-ci:
     name: Test CI - JDK ${{ matrix.java-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ cd ./dynamic-datasource/
 ./mvnw -am -pl dynamic-datasource-spring-boot3-starter -PnativeTestInSpringBoot -T1C -B clean test
 ```
 
-贡献者在提交 PR 后，位于 Github Actions 的 CI 将进行此验证。相关 CI 的失败行为是现阶段是可接受的。
+贡献者在提交 PR 后，位于 Github Actions 的 CI 将进行此验证。
 
 请不要为 SPEL 功能编写可能的 nativeTest，参考 https://github.com/spring-projects/spring-framework/issues/29548 。如有需要，
 请使用 `org.graalvm.nativeimage.imagecode` 的 System Property 屏蔽相关测试在 GraalVM Native Image 下运行。

--- a/dynamic-datasource-spring-boot-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/dynamic-datasource-spring-boot-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -64,8 +64,8 @@ public class DynamicDataSourceAutoConfiguration implements InitializingBean {
 
     @Bean
     @ConditionalOnMissingBean
-    public DataSource dataSource() {
-        DynamicRoutingDataSource dataSource = new DynamicRoutingDataSource();
+    public DataSource dataSource(List<DynamicDataSourceProvider> providers) {
+        DynamicRoutingDataSource dataSource = new DynamicRoutingDataSource(providers);
         dataSource.setPrimary(properties.getPrimary());
         dataSource.setStrict(properties.getStrict());
         dataSource.setStrategy(properties.getStrategy());

--- a/dynamic-datasource-spring-boot3-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/dynamic-datasource-spring-boot3-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -16,6 +16,7 @@
 package com.baomidou.dynamic.datasource.spring.boot.autoconfigure;
 
 import com.baomidou.dynamic.datasource.DynamicRoutingDataSource;
+import com.baomidou.dynamic.datasource.provider.DynamicDataSourceProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.ObjectProvider;
@@ -64,8 +65,8 @@ public class DynamicDataSourceAutoConfiguration implements InitializingBean {
 
     @Bean
     @ConditionalOnMissingBean
-    public DataSource dataSource() {
-        DynamicRoutingDataSource dataSource = new DynamicRoutingDataSource();
+    public DataSource dataSource(List<DynamicDataSourceProvider> providers) {
+        DynamicRoutingDataSource dataSource = new DynamicRoutingDataSource(providers);
         dataSource.setPrimary(properties.getPrimary());
         dataSource.setStrict(properties.getStrict());
         dataSource.setStrategy(properties.getStrategy());

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/DynamicRoutingDataSource.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/DynamicRoutingDataSource.java
@@ -29,7 +29,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -48,6 +48,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 1.0.0
  */
 @Slf4j
+@Component
 public class DynamicRoutingDataSource extends AbstractRoutingDataSource implements InitializingBean, DisposableBean {
 
     private static final String UNDERLINE = "_";
@@ -59,8 +60,7 @@ public class DynamicRoutingDataSource extends AbstractRoutingDataSource implemen
      * 分组数据库
      */
     private final Map<String, GroupDataSource> groupDataSources = new ConcurrentHashMap<>();
-    @Autowired
-    private List<DynamicDataSourceProvider> providers;
+    private final List<DynamicDataSourceProvider> providers;
     @Setter
     private Class<? extends DynamicDataSourceStrategy> strategy = LoadBalanceDynamicDataSourceStrategy.class;
     @Setter
@@ -71,6 +71,10 @@ public class DynamicRoutingDataSource extends AbstractRoutingDataSource implemen
     private Boolean p6spy = false;
     @Setter
     private Boolean seata = false;
+
+    public DynamicRoutingDataSource(List<DynamicDataSourceProvider> providers) {
+        this.providers = providers;
+    }
 
     @Override
     protected String getPrimary() {
@@ -207,7 +211,7 @@ public class DynamicRoutingDataSource extends AbstractRoutingDataSource implemen
     }
 
     @Override
-    public void destroy() throws Exception {
+    public void destroy() {
         log.info("dynamic-datasource start closing ....");
         for (Map.Entry<String, DataSource> item : dataSourceMap.entrySet()) {
             closeDataSource(item.getKey(), item.getValue());
@@ -216,7 +220,7 @@ public class DynamicRoutingDataSource extends AbstractRoutingDataSource implemen
     }
 
     @Override
-    public void afterPropertiesSet() throws Exception {
+    public void afterPropertiesSet() {
         // 检查开启了配置但没有相关依赖
         checkEnv();
         // 添加并分组数据源

--- a/pom.xml
+++ b/pom.xml
@@ -378,9 +378,9 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${maven-surefire-plugin.version}</version>
                         <configuration>
-                            <excludes>
-                                <exclude>com.baomidou.dynamic.datasource.fixture.v1.**</exclude>
-                            </excludes>
+                            <includes>
+                                <exclude>com.baomidou.dynamic.datasource.fixture.v3.**</exclude>
+                            </includes>
                             <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED</argLine>
                         </configuration>
                     </plugin>
@@ -429,13 +429,6 @@
         </profile>
         <profile>
             <id>nativeTestInSpringBoot</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.junit.platform</groupId>
-                    <artifactId>junit-platform-launcher</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**

- Fixes #465.
- Fixes #535.
- Open and Fix NativeTest by Spring Framework under GraalVM CE.

**Other information:**

- `DynamicRoutingDataSource` has design flaws. This class attempts to inject a `List<DynamicDataSourceProvider>` Spring Bean into a non-container environment, which causes the Spring Framework to deliberately take over this class and set a NoArgConstructor for this class with an unaligned parameter list. 

- As a fix, I added a AllArgsConstructor for `DynamicRoutingDataSource` to avoid https://github.com/baomidou/dynamic-datasource/actions/runs/6080472779/job/16494489274?pr=560 display, injected `List<DynamicDataSourceProvider>`  is null. 

- Similarly, Alibaba Druid's Spring Boot Starter has a similar problem with Spring Bean introspection failures, resulting in the Spring Framework's improper initialization of beans. 

