### PR TITLE
feat: gracy destory datasource 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ spring:
     dynamic:
       primary: master #设置默认的数据源或者数据源组,默认值即为master
       strict: false #严格匹配数据源,默认false. true未匹配到指定数据源时抛异常,false使用默认数据源
+      grace-destroy: false #是否优雅关闭数据源，默认为false，设置为true时，关闭数据源时如果数据源中还存在活跃连接，至多等待10s后强制关闭
       datasource:
         master:
           url: jdbc:mysql://xx.xx.xx.xx:3306/dynamic

--- a/dynamic-datasource-spring-boot-common/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceProperties.java
+++ b/dynamic-datasource-spring-boot-common/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceProperties.java
@@ -69,6 +69,10 @@ public class DynamicDataSourceProperties {
      */
     private Boolean lazy = false;
     /**
+     * 是否优雅关闭数据源,等待一段时间后再将数据源销毁
+     */
+    private Boolean graceDestroy = false;
+    /**
      * seata使用模式，默认AT
      */
     private SeataMode seataMode = SeataMode.AT;

--- a/dynamic-datasource-spring-boot-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/dynamic-datasource-spring-boot-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -71,6 +71,7 @@ public class DynamicDataSourceAutoConfiguration implements InitializingBean {
         dataSource.setStrategy(properties.getStrategy());
         dataSource.setP6spy(properties.getP6spy());
         dataSource.setSeata(properties.getSeata());
+        dataSource.setGraceDestroy(properties.getGraceDestroy());
         return dataSource;
     }
 

--- a/dynamic-datasource-spring-boot-starter/src/test/java/com/baomidou/dynamic/datasource/fixture/v1/AddRemoveDatasourceTest.java
+++ b/dynamic-datasource-spring-boot-starter/src/test/java/com/baomidou/dynamic/datasource/fixture/v1/AddRemoveDatasourceTest.java
@@ -53,6 +53,18 @@ public class AddRemoveDatasourceTest {
         dataSourceProperty.setUrl("jdbc:h2:mem:test1");
         dataSourceProperty.setDriverClassName("org.h2.Driver");
         DynamicRoutingDataSource ds = (DynamicRoutingDataSource) dataSource;
+        // async destroy datasource
+        ds.setGraceDestroy(true);
+        ds.addDataSource(dataSourceProperty.getPoolName(), dataSourceCreator.createDataSource(dataSourceProperty));
+        assertThat(ds.getDataSources().keySet()).contains("slave_1");
+        ds.removeDataSource("slave_1");
+        try {
+            Thread.sleep(6000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        // close directly
+        ds.setGraceDestroy(false);
         ds.addDataSource(dataSourceProperty.getPoolName(), dataSourceCreator.createDataSource(dataSourceProperty));
         assertThat(ds.getDataSources().keySet()).contains("slave_1");
         ds.removeDataSource("slave_1");

--- a/dynamic-datasource-spring-boot-starter/src/test/java/com/baomidou/dynamic/datasource/fixture/v1/AddRemoveDatasourceTest.java
+++ b/dynamic-datasource-spring-boot-starter/src/test/java/com/baomidou/dynamic/datasource/fixture/v1/AddRemoveDatasourceTest.java
@@ -58,11 +58,6 @@ public class AddRemoveDatasourceTest {
         ds.addDataSource(dataSourceProperty.getPoolName(), dataSourceCreator.createDataSource(dataSourceProperty));
         assertThat(ds.getDataSources().keySet()).contains("slave_1");
         ds.removeDataSource("slave_1");
-        try {
-            Thread.sleep(6000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
         // close directly
         ds.setGraceDestroy(false);
         ds.addDataSource(dataSourceProperty.getPoolName(), dataSourceCreator.createDataSource(dataSourceProperty));

--- a/dynamic-datasource-spring-boot3-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/dynamic-datasource-spring-boot3-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -72,6 +72,7 @@ public class DynamicDataSourceAutoConfiguration implements InitializingBean {
         dataSource.setStrategy(properties.getStrategy());
         dataSource.setP6spy(properties.getP6spy());
         dataSource.setSeata(properties.getSeata());
+        dataSource.setGraceDestroy(properties.getGraceDestroy());
         return dataSource;
     }
 

--- a/dynamic-datasource-spring-boot3-starter/src/test/java/com/baomidou/dynamic/datasource/fixture/v3/AddRemoveDatasourceTest.java
+++ b/dynamic-datasource-spring-boot3-starter/src/test/java/com/baomidou/dynamic/datasource/fixture/v3/AddRemoveDatasourceTest.java
@@ -53,6 +53,18 @@ public class AddRemoveDatasourceTest {
         dataSourceProperty.setUrl("jdbc:h2:mem:test1");
         dataSourceProperty.setDriverClassName("org.h2.Driver");
         DynamicRoutingDataSource ds = (DynamicRoutingDataSource) dataSource;
+        // async destroy datasource
+        ds.setGraceDestroy(true);
+        ds.addDataSource(dataSourceProperty.getPoolName(), dataSourceCreator.createDataSource(dataSourceProperty));
+        assertThat(ds.getDataSources().keySet()).contains("slave_1");
+        ds.removeDataSource("slave_1");
+        try {
+            Thread.sleep(6000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        // close directly
+        ds.setGraceDestroy(false);
         ds.addDataSource(dataSourceProperty.getPoolName(), dataSourceCreator.createDataSource(dataSourceProperty));
         assertThat(ds.getDataSources().keySet()).contains("slave_1");
         ds.removeDataSource("slave_1");

--- a/dynamic-datasource-spring-boot3-starter/src/test/java/com/baomidou/dynamic/datasource/fixture/v3/AddRemoveDatasourceTest.java
+++ b/dynamic-datasource-spring-boot3-starter/src/test/java/com/baomidou/dynamic/datasource/fixture/v3/AddRemoveDatasourceTest.java
@@ -58,11 +58,6 @@ public class AddRemoveDatasourceTest {
         ds.addDataSource(dataSourceProperty.getPoolName(), dataSourceCreator.createDataSource(dataSourceProperty));
         assertThat(ds.getDataSources().keySet()).contains("slave_1");
         ds.removeDataSource("slave_1");
-        try {
-            Thread.sleep(6000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
         // close directly
         ds.setGraceDestroy(false);
         ds.addDataSource(dataSourceProperty.getPoolName(), dataSourceCreator.createDataSource(dataSourceProperty));

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/DynamicRoutingDataSource.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/DynamicRoutingDataSource.java
@@ -295,9 +295,9 @@ public class DynamicRoutingDataSource extends AbstractRoutingDataSource implemen
             if (null != realDataSource) {
                 DataSourceDestroyer destroyer = new DefaultDataSourceDestroyer();
                 if (graceDestroy) {
-                    destroyer.asyncDestroy(ds, dataSource);
+                    destroyer.asyncDestroy(ds, realDataSource);
                 } else {
-                    destroyer.destroy(ds, dataSource);
+                    destroyer.destroy(ds, realDataSource);
                 }
             }
         } catch (Exception e) {

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/DataSourceActiveDetector.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/DataSourceActiveDetector.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2018 organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.dynamic.datasource.destroyer;
+
+import javax.sql.DataSource;
+
+/**
+ * Description
+ * Detect if the datasource contains active connections
+ *
+ * @author alvinkwok
+ * @since 2023/10/18
+ */
+public interface DataSourceActiveDetector {
+    boolean containsActiveConnection(DataSource dataSource);
+
+    boolean support(DataSource dataSource);
+}

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/DataSourceDestroyer.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/DataSourceDestroyer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018 organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.dynamic.datasource.destroyer;
+
+import javax.sql.DataSource;
+
+/**
+ * Used to destroy sources
+ */
+public interface DataSourceDestroyer {
+
+    void asyncDestroy(String name, DataSource dataSource);
+
+    /**
+     * Immediately destroy the data source
+     *
+     * @param realDataSource wait destroy data source
+     */
+    void destroy(String name, DataSource realDataSource);
+}

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/DefaultDataSourceDestroyer.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/DefaultDataSourceDestroyer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2018 organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.dynamic.datasource.destroyer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.ReflectionUtils;
+
+import javax.sql.DataSource;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Description
+ * DefaultDataSourceDestroyer,  support all sources
+ *
+ * @author alvinkwok
+ * @since 2023/10/18
+ */
+@Slf4j
+public class DefaultDataSourceDestroyer implements DataSourceDestroyer {
+
+    private static final String THREAD_NAME = "close-db";
+
+    public void asyncDestroy(String name, DataSource dataSource) {
+        ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+            Thread thread = new Thread(r);
+            thread.setName(THREAD_NAME);
+            return thread;
+        });
+        log.warn("dynamic-datasource async close the datasource named [{}],", name);
+        executor.execute(() -> {
+            try {
+                Thread.sleep(5000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            destroy(name, dataSource);
+        });
+        executor.shutdown();
+    }
+
+    /**
+     * Immediately destroy the data source
+     *
+     * @param realDataSource wait destroy data source
+     */
+    public void destroy(String name, DataSource realDataSource) {
+        Class<? extends DataSource> clazz = realDataSource.getClass();
+        try {
+            Method closeMethod = ReflectionUtils.findMethod(clazz, "close");
+            if (closeMethod != null) {
+                closeMethod.invoke(realDataSource);
+                log.info("dynamic-datasource close the datasource named [{}]  success,", name);
+            }
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            log.warn("dynamic-datasource close the datasource named [{}] failed,", name, e);
+        }
+    }
+}

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/Dhcp2DataSourceActiveDetector.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/Dhcp2DataSourceActiveDetector.java
@@ -21,24 +21,21 @@ import javax.sql.DataSource;
 
 /**
  * Description
- * Hikari data source pool active detector.
+ * DHCP2 data source pool active detector.
  *
  * @author alvinkwok
  * @since 2023/10/18
  */
-public class HikariDataSourceActiveDetector implements DataSourceActiveDetector {
+public class Dhcp2DataSourceActiveDetector implements DataSourceActiveDetector {
     @Override
     @SneakyThrows(ReflectiveOperationException.class)
     public boolean containsActiveConnection(DataSource dataSource) {
-        Object hikariPoolMXBean = dataSource.getClass().getMethod("getHikariPoolMXBean").invoke(dataSource);
-        int activeCount = null == hikariPoolMXBean
-                ? 0
-                : (int) hikariPoolMXBean.getClass().getMethod("getActiveConnections").invoke(hikariPoolMXBean);
+        int activeCount = (int) dataSource.getClass().getMethod("getNumActive").invoke(dataSource);
         return activeCount != 0;
     }
 
     @Override
     public boolean support(DataSource dataSource) {
-        return "com.zaxxer.hikari.HikariDataSource".equals(dataSource.getClass().getName());
+        return "org.apache.commons.dbcp2.BasicDataSource".equals(dataSource.getClass().getName());
     }
 }

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/DruidDataSourceActiveDetector.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/DruidDataSourceActiveDetector.java
@@ -21,24 +21,21 @@ import javax.sql.DataSource;
 
 /**
  * Description
- * Hikari data source pool active detector.
+ * alibaba Druid data source pool active detector.
  *
  * @author alvinkwok
  * @since 2023/10/18
  */
-public class HikariDataSourceActiveDetector implements DataSourceActiveDetector {
+public class DruidDataSourceActiveDetector implements DataSourceActiveDetector {
     @Override
     @SneakyThrows(ReflectiveOperationException.class)
     public boolean containsActiveConnection(DataSource dataSource) {
-        Object hikariPoolMXBean = dataSource.getClass().getMethod("getHikariPoolMXBean").invoke(dataSource);
-        int activeCount = null == hikariPoolMXBean
-                ? 0
-                : (int) hikariPoolMXBean.getClass().getMethod("getActiveConnections").invoke(hikariPoolMXBean);
+        int activeCount = (int) dataSource.getClass().getMethod("getActiveCount").invoke(dataSource);
         return activeCount != 0;
     }
 
     @Override
     public boolean support(DataSource dataSource) {
-        return "com.zaxxer.hikari.HikariDataSource".equals(dataSource.getClass().getName());
+        return "com.alibaba.druid.pool.DruidDataSource".equals(dataSource.getClass().getName());
     }
 }

--- a/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/HikariDataSourceActiveDetector.java
+++ b/dynamic-datasource-spring/src/main/java/com/baomidou/dynamic/datasource/destroyer/HikariDataSourceActiveDetector.java
@@ -1,0 +1,29 @@
+package com.baomidou.dynamic.datasource.destroyer;
+
+import lombok.SneakyThrows;
+
+import javax.sql.DataSource;
+
+/**
+ * Description
+ * Hikari data source pool active detector.
+ *
+ * @author alvinkwok
+ * @since 2023/10/18
+ */
+public class HikariDataSourceActiveDetector implements DataSourceActiveDetector {
+    @Override
+    @SneakyThrows(ReflectiveOperationException.class)
+    public boolean containsActiveConnection(DataSource dataSource) {
+        Object hikariPoolMXBean = dataSource.getClass().getMethod("getHikariPoolMXBean").invoke(dataSource);
+        int activeCount = null == hikariPoolMXBean
+                ? 0
+                : (int) hikariPoolMXBean.getClass().getMethod("getActiveConnections").invoke(hikariPoolMXBean);
+        return activeCount != 0;
+    }
+
+    @Override
+    public boolean support(DataSource dataSource) {
+        return "com.zaxxer.hikari.HikariDataSource".equals(dataSource.getClass().getName());
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style
- [ ] Refactor
- [x] Doc
- [ ] Other, please describe:

**The description of the PR:**

Fixes #578

添加运行时优雅关闭数据源的功能，该特性可以通过配置spring.datasource.dynamic.gracy-destory = true 打开。

打开后，在运行时销毁数据源将会开启异步任务延迟销毁数据源。对HikariCP，druid，DHCP2能够支持检测是否含有活跃连接，在没有活跃连接的情况下立即关闭数据源，至多10s，超时后会直接强制关闭；对于不支持的数据源10s后再关闭数据源。

在dynamic-datasource调用destroy的时候强制销毁，不进行异步关闭。

优雅关闭数据源的代码中每次进行异步关闭都会开启一个线程池，从实际情况来看，覆盖数据源配置或者移除数据源配置是一个很低频的操作，并不会产生不良影响。

**Other information:**

更新了使用文档


