### PR TITLE
Remove Maven config that exclude tomcat dependency under Springboot3 …

### DIFF
--- a/dynamic-datasource-spring-boot3-starter/pom.xml
+++ b/dynamic-datasource-spring-boot3-starter/pom.xml
@@ -28,16 +28,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-tomcat</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-undertow</artifactId>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>


### PR DESCRIPTION
…module

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [x] Other, please describe:

**The description of the PR:**

Remove Maven config that exclude tomcat dependency under Springboot3 module

Fixes [4.2.0的dynamic-datasource-spring-boot3-starter/pom.xml中不应更改web容器为undertow，应由用户自己决定](https://github.com/baomidou/dynamic-datasource/issues/587) #587 
**Other information:**



