### PR TITLE
perf: @Bean初始化优化, 以消除日志:is not eligible for getting processed by all BeanPostProcessors

### DIFF
--- a/dynamic-datasource-spring-boot-common/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAssistConfiguration.java
+++ b/dynamic-datasource-spring-boot-common/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAssistConfiguration.java
@@ -26,7 +26,6 @@ import com.baomidou.dynamic.datasource.strategy.DynamicDataSourceStrategy;
 import com.baomidou.dynamic.datasource.tx.DsTxEventListenerFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -44,7 +43,6 @@ import java.util.List;
  */
 @Configuration
 @RequiredArgsConstructor
-@EnableConfigurationProperties(DynamicDataSourceProperties.class)
 public class DynamicDataSourceAssistConfiguration {
 
     private final DynamicDataSourceProperties properties;

--- a/dynamic-datasource-spring-boot-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAopConfiguration.java
+++ b/dynamic-datasource-spring-boot-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAopConfiguration.java
@@ -32,7 +32,6 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
@@ -47,8 +46,8 @@ import org.springframework.context.expression.BeanFactoryResolver;
  * @see DynamicRoutingDataSource
  * @since 1.0.0
  */
-@Configuration
-@EnableConfigurationProperties(DynamicDataSourceProperties.class)
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+@Configuration(proxyBeanMethods = false)
 public class DynamicDataSourceAopConfiguration {
 
     private final DynamicDataSourceProperties properties;
@@ -57,6 +56,13 @@ public class DynamicDataSourceAopConfiguration {
         this.properties = properties;
     }
 
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    @Bean
+    public static DynamicDataSourceProperties dynamicDataSourceProperties() {
+        return new DynamicDataSourceProperties();
+    }
+
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     @Bean
     @ConditionalOnMissingBean
     public DsProcessor dsProcessor(BeanFactory beanFactory) {
@@ -68,7 +74,6 @@ public class DynamicDataSourceAopConfiguration {
         sessionProcessor.setNextProcessor(spelExpressionProcessor);
         return headerProcessor;
     }
-
 
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     @Bean

--- a/dynamic-datasource-spring-boot-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/dynamic-datasource-spring-boot-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -25,7 +25,6 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -45,7 +44,6 @@ import java.util.List;
  */
 @Slf4j
 @Configuration
-@EnableConfigurationProperties(DynamicDataSourceProperties.class)
 @AutoConfigureBefore(value = DataSourceAutoConfiguration.class, name = "com.alibaba.druid.spring.boot.autoconfigure.DruidDataSourceAutoConfigure")
 @Import({DruidDynamicDataSourceConfiguration.class, DynamicDataSourceCreatorAutoConfiguration.class, DynamicDataSourceAopConfiguration.class, DynamicDataSourceAssistConfiguration.class})
 @ConditionalOnProperty(prefix = DynamicDataSourceProperties.PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)

--- a/dynamic-datasource-spring-boot3-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAopConfiguration.java
+++ b/dynamic-datasource-spring-boot3-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAopConfiguration.java
@@ -32,7 +32,6 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
@@ -47,8 +46,7 @@ import org.springframework.context.expression.BeanFactoryResolver;
  * @see DynamicRoutingDataSource
  * @since 1.0.0
  */
-@Configuration
-@EnableConfigurationProperties(DynamicDataSourceProperties.class)
+@Configuration(proxyBeanMethods = false)
 public class DynamicDataSourceAopConfiguration {
 
     private final DynamicDataSourceProperties properties;
@@ -57,6 +55,13 @@ public class DynamicDataSourceAopConfiguration {
         this.properties = properties;
     }
 
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    @Bean
+    public static DynamicDataSourceProperties dynamicDataSourceProperties() {
+        return new DynamicDataSourceProperties();
+    }
+
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     @Bean
     @ConditionalOnMissingBean
     public DsProcessor dsProcessor(BeanFactory beanFactory) {

--- a/dynamic-datasource-spring-boot3-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/dynamic-datasource-spring-boot3-starter/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -40,8 +40,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @Slf4j
-@Configuration
-@EnableConfigurationProperties(DynamicDataSourceProperties.class)
+@Configuration(proxyBeanMethods = false)
 @AutoConfigureBefore(
         value = DataSourceAutoConfiguration.class,
         name = {


### PR DESCRIPTION
1. 由于Advisor会优先初始化,故相关@Bean应加: @Role(BeanDefinition.ROLE_INFRASTRUCTURE) 以消除:is not eligible for getting processed by all BeanPostProcessors

2. 去除@EnableConfigurationProperties(DynamicDataSourceProperties.class) 改为static方式配置是为了加@Role(BeanDefinition.ROLE_INFRASTRUCTURE)

3. spring 5.2+ 配置类如不内部不存在@Bean方法引用应加: proxyBeanMethods = false 以去除不必要代理类 肖：ie: `@Configuration(proxyBeanMethods = false)`

此PR是了消除启动时的以下日志:

```
 [restartedMain] INFO  o.s.c.s.PostProcessorRegistrationDelegate$BeanPostProcessorChecker[376] - Bean 'spring.datasource.dynamic-com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceProperties' of type [com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceProperties] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
12-23 09:29:16.779 [restartedMain] INFO  o.s.c.s.PostProcessorRegistrationDelegate$BeanPostProcessorChecker[376] - Bean 'dsProcessor' of type [com.baomidou.dynamic.datasource.processor.DsHeaderProcessor] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
```

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style
- [X] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
@Bean初始化优化, 以消除日志:is not eligible for getting processed by all BeanPostProcessors

**Other information:**



