### PR TITLE
chore: license.txt位置可配置以解决子项目下构建失败问题

### DIFF
--- a/dynamic-datasource-creator/pom.xml
+++ b/dynamic-datasource-creator/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dynamic-datasource-creator</artifactId>
     <url>https://github.com/baomidou/dynamic-datasource-spring-boot-starter/tree/master/dynamic-datasource-creator</url>
 
+    <properties>
+        <license-file>../license.txt</license-file>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.alibaba</groupId>

--- a/dynamic-datasource-spring-boot-common/pom.xml
+++ b/dynamic-datasource-spring-boot-common/pom.xml
@@ -14,6 +14,10 @@
         https://github.com/baomidou/dynamic-datasource-spring-boot-starter/tree/master/dynamic-datasource-spring-boot-common
     </url>
 
+    <properties>
+        <license-file>../license.txt</license-file>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.baomidou</groupId>

--- a/dynamic-datasource-spring-boot-starter/pom.xml
+++ b/dynamic-datasource-spring-boot-starter/pom.xml
@@ -14,6 +14,10 @@
         https://github.com/baomidou/dynamic-datasource-spring-boot-starter/tree/master/dynamic-datasource-spring-boot-starter
     </url>
 
+    <properties>
+        <license-file>../license.txt</license-file>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.baomidou</groupId>

--- a/dynamic-datasource-spring-boot3-starter/pom.xml
+++ b/dynamic-datasource-spring-boot3-starter/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <java.version>17</java.version>
         <spring-boot-dependencies.version>3.1.5</spring-boot-dependencies.version>
+        <license-file>../license.txt</license-file>
     </properties>
 
     <dependencies>

--- a/dynamic-datasource-spring/pom.xml
+++ b/dynamic-datasource-spring/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>dynamic-datasource-spring</artifactId>
     <url>https://github.com/baomidou/dynamic-datasource-spring-boot-starter/tree/master/dynamic-datasource-spring</url>
 
+    <properties>
+        <license-file>../license.txt</license-file>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.baomidou</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
 
         <license-maven-plugin.version>4.3</license-maven-plugin.version>
+        <license-file>license.txt</license-file>
         <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <native-maven-plugin.version>0.9.28</native-maven-plugin.version>
@@ -232,7 +233,7 @@
                 <configuration>
                     <licenseSets>
                         <licenseSet>
-                            <header>license.txt</header>
+                            <header>${license-file}</header>
                             <includes>
                                 <include>src/main/java/**</include>
                             </includes>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [X] Other, please describe:

**The description of the PR:**

 license.txt位置可配置以解决子项目下构建失败问题
```
[ERROR] Failed to execute goal com.mycila:license-maven-plugin:4.3:check (default) on project dynamic-datasource-spring-boot-starter: Execution default of goal com.mycila:license-maven-plugin:4.3:check failed: Cannot read header document license.txt. Cause: Resource license.txt not found in file system, classpath or URL: no protocol: license.txt -> [Help 1]
```

**Other information:**



