### PR TITLE
feat: 增加 MySQL Connector/J 5.1 XADataSource 的支持

### DIFF
--- a/dynamic-datasource-creator/src/main/java/com/baomidou/dynamic/datasource/enums/XADataSourceEnum.java
+++ b/dynamic-datasource-creator/src/main/java/com/baomidou/dynamic/datasource/enums/XADataSourceEnum.java
@@ -25,6 +25,10 @@ import lombok.Getter;
 @Getter
 public enum XADataSourceEnum {
     /**
+     * <a href="https://dev.mysql.com/doc/connector-j/en/connector-j-api-changes.html">MySQL Connector/J 5.1 使用老的 MysqlXADataSource</a>
+     */
+    MYSQL_CONNECTOR_J_5("com.mysql.jdbc.jdbc2.optional.MysqlXADataSource"),
+    /**
      * mysql
      */
     MYSQL("com.mysql.cj.jdbc.MysqlXADataSource"),


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**

项目中使用 mysql-connector-java 5.1 版本的时候，需要使用老版的 MysqlXADataSource 才能创建 atomikos 数据源

**Other information:**



